### PR TITLE
Fix duplication when dragging between sortable lists

### DIFF
--- a/src/lib/data/character/equipment.ts
+++ b/src/lib/data/character/equipment.ts
@@ -39,6 +39,9 @@ export class Item {
 	@autoserialize
 	isContainer = false;
 
+	@autoserialize
+	containerOpen = false;
+
 	@autoserializeAs(Item)
 	children: Item[] = [];
 

--- a/src/lib/nested-equipment-list.svelte
+++ b/src/lib/nested-equipment-list.svelte
@@ -27,73 +27,76 @@
 	}
 </script>
 
-<SortableList
-	bind:items
-	keyPrefix={parentId}
-	options={{
-		group: 'items',
-		handle: '.drag-handle',
-		animation: 150,
-		easing: 'cubic-bezier(1, 0, 0, 1)',
-		fallbackOnBody: true,
-		swapThreshold: 0.65
-	}}
-	{onMove}
-	keyProp="id"
-	{disabled}
-	class="flex flex-col gap-2 {className}"
-	let:item
-	let:index
->
-	<div class="flex w-full flex-auto flex-row">
-		<div class="drag-handle flex w-6 items-center justify-center" role="button" tabindex="0">
-			<DragHandle />
-		</div>
+{#key items.length}
+	<SortableList
+		bind:items
+		keyPrefix={parentId}
+		options={{
+			group: 'items',
+			handle: '.drag-handle',
+			animation: 150,
+			easing: 'cubic-bezier(1, 0, 0, 1)',
+			fallbackOnBody: true,
+			swapThreshold: 0.65
+		}}
+		{onMove}
+		keyProp="id"
+		{disabled}
+		class="flex flex-col gap-2 {className}"
+		let:item
+		let:index
+	>
+		<div class="flex w-full flex-auto flex-row">
+			<div class="drag-handle flex w-6 items-center justify-center" role="button" tabindex="0">
+				<DragHandle />
+			</div>
 
-		{#if !item.isContainer}
-			<button
-				class="btn btn-sm md:btn-md min-w-0 flex-auto truncate"
-				on:click|stopPropagation={() => macroNotify(item.name, item.description, $c)}
-				on:contextmenu|preventDefault|stopPropagation={() =>
-					openDialog(ItemDialog, { list: items, index })}
-			>
-				<span class="truncate">
-					{item.quantity}x {item.name}
-				</span>
-			</button>
-			{#if item.chargeType !== 'none'}
+			{#if !item.isContainer}
 				<button
-					class="btn btn-accent btn-sm md:btn-md ml-2 w-28 px-2"
-					on:click|stopPropagation={() => items[index].remaining > 0 && items[index].remaining--}
+					class="btn btn-sm md:btn-md min-w-0 flex-auto truncate"
+					on:click|stopPropagation={() => macroNotify(item.name, item.description, $c)}
+					on:contextmenu|preventDefault|stopPropagation={() =>
+						openDialog(ItemDialog, { list: items, index })}
 				>
-					{item.remaining}{#if item.chargeType === 'perDay'}
-						/{item.perDay}
-					{/if} charges
+					<span class="truncate">
+						{item.quantity}x {item.name}
+					</span>
 				</button>
-			{/if}
-		{:else}
-			<Collapse
-				icon="arrow"
-				on:click={() => macroNotify(item.name, item.description, $c)}
-				on:contextmenu={() => openDialog(ItemDialog, { list: items, index })}
-				let:open
-			>
-				<svelte:fragment slot="title">
-					<span class="text-sm font-semibold" class:underline={item.equipped}>
-						{item.name}
-					</span>
-					<span class="badge badge-md">
-						{$t('equipment.items', item.children.length)}
-					</span>
-				</svelte:fragment>
+				{#if item.chargeType !== 'none'}
+					<button
+						class="btn btn-accent btn-sm md:btn-md ml-2 w-28 px-2"
+						on:click|stopPropagation={() => items[index].remaining > 0 && items[index].remaining--}
+					>
+						{item.remaining}{#if item.chargeType === 'perDay'}
+							/{item.perDay}
+						{/if} charges
+					</button>
+				{/if}
+			{:else}
+				<Collapse
+					icon="arrow"
+					bind:open={items[index].containerOpen}
+					on:click={() => macroNotify(item.name, item.description, $c)}
+					on:contextmenu={() => openDialog(ItemDialog, { list: items, index })}
+					let:open
+				>
+					<svelte:fragment slot="title">
+						<span class="text-sm font-semibold" class:underline={item.equipped}>
+							{item.name}
+						</span>
+						<span class="badge badge-md">
+							{$t('equipment.items', item.children.length)}
+						</span>
+					</svelte:fragment>
 
-				<svelte:self
-					bind:items={items[index].children}
-					parentId={item.id}
-					disabled={!open}
-					class="bg-base-100 rounded-lg p-2 pl-0"
-				/>
-			</Collapse>
-		{/if}
-	</div>
-</SortableList>
+					<svelte:self
+						bind:items={items[index].children}
+						parentId={item.id}
+						disabled={!open}
+						class="bg-base-100 rounded-lg p-2 pl-0"
+					/>
+				</Collapse>
+			{/if}
+		</div>
+	</SortableList>
+{/key}


### PR DESCRIPTION
Quick workaround: Re-mount the entire list whenever such a change occurs.
Also save the open-state of containers, so the user doesn't notice

Fixes #8 